### PR TITLE
Update config.edn

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -6,4 +6,5 @@
            keechma.next.toolbox.pipeline/pipeline!     cljs.core/fn}
  :linters {:unused-binding {:exclude-destructured-keys-in-fn-args true}
            :unresolved-symbol {:exclude [(keechma.next.helix.lib/defnc [props])
+                                         (keechma.pipelines.core/pipeline!)
                                          (keechma.next.helix.template/defnt [configurable slot optional-slot])]}}}


### PR DESCRIPTION
I propose we add `(keechma.pipelines.core/pipeline!)` to the exclude list of unresolved symbol linter. 
In my VScode setup, I see linting errors for the `(rescue! [error])` block so this config resolves that with a hammer.

If I missed something, please let me know or if others don't have the same problems. 